### PR TITLE
Restored missing <script> tags in index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # vue-todo-app
-Learn Vue.js doing a Todo app with routing
+Learn Vue.js doing a Todo app with routing.
+The full guide can be found [here](https://adrianmejia.com/blog/2018/08/04/vue-js-tutorial-for-beginners-create-a-todo-app).

--- a/index.html
+++ b/index.html
@@ -70,8 +70,10 @@
   <footer class="info">
     <p>Double-click to edit a todo</p>
   </footer>
-
+  
   <!-- Scripts here ↓ -->
+  <script src="node_modules/vue/dist/vue.js"></script>
+  <script src="node_modules/vue-router/dist/vue-router.js"></script>
   <script src="app.js"></script>
 </body>
 


### PR DESCRIPTION
Script tags were missing and this resulted in "ReferenceError: Vue is not defined" when loading the page.

Also, updated README to point out to the blog post that has the actual guide, just in case finds this directly on github.